### PR TITLE
fix: disable imageSmoothing in canvas datagrid

### DIFF
--- a/Build/packages/datagrid/src/typo3-datagrid.ts
+++ b/Build/packages/datagrid/src/typo3-datagrid.ts
@@ -266,6 +266,7 @@ export class Typo3Datagrid extends LitElement {
 
         this._handleDisabledRow(e);
 
+        e.ctx.imageSmoothingEnabled = false;
         e.ctx.drawImage(image, x, y, targetWidth, targetHeight);
       }
     }


### PR DESCRIPTION
fixes: #12